### PR TITLE
Added a "leave group" link to the show pages of groups

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -32,6 +32,12 @@ class GroupsController < ApplicationController
     redirect_to group
   end
 
+  def leave
+    group = Group.find(params[:id])
+    current_user.groups.delete(group)
+    redirect_to root
+  end
+
   private
 
   def group_params

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -35,7 +35,7 @@ class GroupsController < ApplicationController
   def leave
     group = Group.find(params[:id])
     current_user.groups.delete(group)
-    redirect_to root
+    redirect_to root_path
   end
 
   private

--- a/app/views/groups/_mentor_group.html.erb
+++ b/app/views/groups/_mentor_group.html.erb
@@ -18,8 +18,8 @@
   <% end %>
 </div>
 
-<%= link_to "Leave group", leave_group_path(@group),
-  data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to leave this group?" },
+<%= link_to "Permanently leave mentor program", leave_group_path(@group),
+  data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to leave the mentor program?" },
   class: "ms-3 text-danger" %>
 
 <div class="tree-bg-mentor-dashboard">

--- a/app/views/groups/_mentor_group.html.erb
+++ b/app/views/groups/_mentor_group.html.erb
@@ -18,5 +18,9 @@
   <% end %>
 </div>
 
+<%= link_to "Leave group", leave_group_path(@group),
+  data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to leave this group?" },
+  class: "ms-3 text-danger" %>
+
 <div class="tree-bg-mentor-dashboard">
 </div>

--- a/app/views/groups/_parent_community.html.erb
+++ b/app/views/groups/_parent_community.html.erb
@@ -22,6 +22,10 @@
   <% end %>
 </div>
 
+<%= link_to "Leave group", leave_group_path(@group),
+  data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to leave this group?" },
+  class: "ms-3 text-danger" %>
+
 <div style="margin-top:300px">
   <div class="btn-hp">
     <%= link_to "Mentor Program", mentor_info_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :groups, only: [:index, :new, :create, :show] do
     member do
       post :join
+      delete :leave
     end
     resources :messages, only: :create
   end


### PR DESCRIPTION
- Added a leave group action the the Groups Controller
- Added a link to leave the group to the show pages of the parent community group and mentor group
- Users can now leave a group if they like and this will "unjoin" them from that group in the backend. This means they can pick another group, for example if they relocate. 