### PR TITLE
Labels on all user forms updated

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -66,7 +66,8 @@ class GroupsController < ApplicationController
     find_group
     return if @group.users.include?(current_user)
 
-    redirect_to root_path, notice: "You aren't a member of this group."
+    flash[:alert] = "You aren't a member of this group."
+    redirect_to root_path
   end
 
   def group_params

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -12,6 +12,16 @@
           <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
         <% end %>
 
+        <%= f.input :first_name,
+                    required: true,
+                    autofocus: true,
+                    input_html: { autocomplete: "given-name" } %>
+        <%= f.input :last_name,
+                    required: true,
+                    autofocus: true,
+                    input_html: { autocomplete: "family-name" } %>
+        <%= f.input :nickname,
+                    input_html: { autocomplete: "nickname" } %>
         <%= f.input :password,
                     hint: "leave it blank if you don't want to change it",
                     required: false,
@@ -30,7 +40,7 @@
         <%= f.button :submit, "Update" %>
       </div>
     <% end %>
-    <p>To cancel your account, simply click <%= link_to "here", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></p>
+    <p>To cancel your account, simply click <%= link_to "here", cancel_user_registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></p>
   </div>
 </div>
 <div class="tree-bg-user-edit">

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,15 +1,15 @@
 <div class="form-flexbox-lhs">
   <div class="white-form-rounded">
   <h2 class="two-color-headline">New<span class="nest-purple">parent community group</span></h2>
-  <p>Can't find the right match for you? There's always a solution at TogetherNest. Fill in this short form to create a new parent community group in your area. Then just wait for other parents to join the group. We look forward to welcoming you and other new members into the nest.</p>
+  <p>Can't find the right match for you? There's always a solution at TogetherNest. Fill in this short form to create a new parent community group in your area. Then just wait for other parents to join the group. We look forward to welcoming you and fellow new members into the nest.</p>
 
   <%= simple_form_for(@group) do |f| %>
     <%= f.error_notification %>
     <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
     <div class="form-inputs">
-      <%= f.input :name %>
-      <%= f.input :post_code,
+      <%= f.input :name, label: "Your parent community group's name" %>
+      <%= f.input :post_code, label: "The postcode for your group's area",
                   as: :string,
                   required: true %>
     </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,6 +1,3 @@
-<!-- <% if current_user.groups.include? @group %>
-  <p>Welcome to your group</p>
-<% end %> -->
 <% if @group_type == "parent community" %>
   <%= render "parent_community"  %>
 <% elsif @group_type == "mentor" %>

--- a/app/views/groups/users.html.erb
+++ b/app/views/groups/users.html.erb
@@ -11,6 +11,7 @@
     <div class="parent-card">
       <%= cl_image_tag user.photo.key, class: "parent-avatar-lg"%>
       <h2><%= user.first_name %></h2>
+      <p><%= user.nickname %></p>
       <p><%= user.bio %></p>
     </div>
   <% end %>

--- a/app/views/mentor_profiles/edit.html.erb
+++ b/app/views/mentor_profiles/edit.html.erb
@@ -7,19 +7,18 @@
 
       <div class="form-inputs">
 
-        <%= f.input :post_code,
+        <%= f.input :post_code, label: "Your postcode",
                     required: true,
                     as: :string,
                     input_html: { autocomplete: "postcode" }  %>
-        <%= f.input :parent_experience,
-                    hint: "Specify how many years you have been parenting",
+        <%= f.input :parent_experience, label: "How many years have you been parenting?",
                     required: true,
                     as: :string,
                     input_html: { autocomplete: "parent experience in years" } %>
-        <%= f.input :bio,
-                    hint: "A detailed bio makes it easier to match you to the right mentee.",
+        <%= f.input :bio, label: "A detailed bio to introduce yourself",
+                    hint: "Having a detailed bio makes it easier to match you to the right mentee.",
                     required: true,
-                    input_html: { autocomplete: "A detailed bio to introduce yourself" } %>
+                    input_html: { autocomplete: "bio" } %>
       </div>
 
       <div class="form-actions">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -7,17 +7,18 @@
 
       <div class="form-inputs">
 
-        <%= f.input :due_date,
+        <%= f.input :due_date, label: "Your baby's due date or DOB",
                     required: true,
                     as: :string,
                     input_html: { autocomplete: "due date", class: "datepicker-input", data: { controller: "datepicker" } }  %>
-        <%= f.input :post_code,
+        <%= f.input :post_code, label: "Your postcode",
                     required: true,
                     as: :string,
                     input_html: { autocomplete: "postcode" } %>
-        <%= f.input :bio,
+        <%= f.input :bio, label: "A bio to introduce yourself",
+                    hint: "A detailed bio makes it easier to match you to the right group or mentor later on.",
                     required: true,
-                    input_html: { autocomplete: "short bio to introduce yourself" } %>
+                    input_html: { autocomplete: "bio" } %>
       </div>
 
       <div class="form-actions">


### PR DESCRIPTION
- Updated the input labels on all forms so that the fields make more sense to the user 
- Updated one of the warning flashes when users try to access a group (in the browser) that they're not a member of
- Added the nickname field to the overview page of all members of a group (nicknames are used in the chat. This way users can look up who they're chatting to)