### PR TITLE
Updated mentor info page

### DIFF
--- a/app/controllers/mentor_profiles_controller.rb
+++ b/app/controllers/mentor_profiles_controller.rb
@@ -1,6 +1,9 @@
 class MentorProfilesController < ApplicationController
   def edit
-    # current_user.parent_experience >= 2
+    # if current_user.parent_experience >= 2
+    # else
+    #   redirect_to root_path, alert: "You need at least 2 years of parent experience to create a mentor profile."
+    # end
   end
 
   def update

--- a/app/controllers/mentor_profiles_controller.rb
+++ b/app/controllers/mentor_profiles_controller.rb
@@ -1,10 +1,11 @@
 class MentorProfilesController < ApplicationController
   def edit
+    # current_user.parent_experience >= 2
   end
 
   def update
     if current_user.update(mentor_params)
-      redirect_to group_path(current_user.groups.where(group_type: "parent community").first), notice: "Your answers were succesfully saved", status: :see_other
+      redirect_to group_path(current_user.groups.where(group_type: "parent community").first), notice: "Your answers have been succesfully saved", status: :see_other
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/mentorships_controller.rb
+++ b/app/controllers/mentorships_controller.rb
@@ -25,7 +25,6 @@ class MentorshipsController < ApplicationController
   end
 
   def show
-    raise
     if current_user.mentor.present? || current_user.mentee.present?
       redirect_to current_user.groups.where(group_type: "mentor").first
     end

--- a/app/views/mentor_profiles/edit.html.erb
+++ b/app/views/mentor_profiles/edit.html.erb
@@ -12,6 +12,7 @@
                     as: :string,
                     input_html: { autocomplete: "postcode" }  %>
         <%= f.input :parent_experience, label: "How many years have you been parenting?",
+                    hint: "A minumum of two years parenting experience is required to become a mentor",
                     required: true,
                     as: :string,
                     input_html: { autocomplete: "parent experience in years" } %>

--- a/app/views/mentor_profiles/edit.html.erb
+++ b/app/views/mentor_profiles/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="form-flexbox-rhs">
   <div class="white-form-rounded">
     <h2 class="two-color-headline">become a<span class="nest-purple">mentor</span></h2>
-    <p>To ensure we find your perfect match with a parent looking for a mentor, please share more about yourself in as much detail as possible. Your answers will enable us to match you seamlessly with a parent needing your expertise and guidance.</p>
+    <p>To ensure we find your perfect match with a parent looking for a mentor, please share more about yourself. Your answers will enable us to match you seamlessly with a parent needing your expertise and guidance.</p>
     <%= simple_form_for(current_user, as: :user, url: mentor_profile_path, html: { method: :patch }) do |f| %>
       <%= f.error_notification %>
 

--- a/app/views/mentorships/show.html.erb
+++ b/app/views/mentorships/show.html.erb
@@ -15,16 +15,22 @@
       A mentor provides a trusted source of guidance, support, and wisdom, offering valuable insights based on their own experiences and knowledge.
     </p>
     <p>
-      They can help you navigate the challenges of parenthood, offering advice on various aspects such as child development, discipline techniques, communication skills, and self-care. A mentor can also serve as a role model, inspiring you to develop positive parenting practices and cultivate a nurturing environment for your children.
+      They can help you navigate the challenges of parenthood, offering advice on various aspects such as child development, communication skills, and self-care. A mentor can also serve as a role model, inspiring you to develop positive parenting practices and cultivate a nurturing environment for your children.
     </p>
     <p>
       Through their encouragement and feedback, a mentor empowers you to build confidence in your parenting abilities. Ultimately, having a mentor by your side can enhance your parenting journey, equipping you with the tools and encouragement needed to thrive as a parent.
     </p>
-    <p>Continue below to join the mentorship program.</p>
+    <p>Continue below to join the mentorship program as a mentee.</p>
     <div class="mentor-info-btn-container">
       <%= link_to "Find a mentor", find_mentorship_path, class: "mentor-info-btn-hp"%>
     </div>
     <p>Are you interested in becoming a Mentor yourself?</p>
+    <p>Being a mentor and guiding a new parent to become more confident in their parenting skills can be greatly rewarding.</p>
+    <p>
+      After having benefited from community and parenting support at Togethernest yourself, why not give back to the community and help someone else navigate the challenges of parenthood? You'll help us offer accessible support to parents in similar circumstance as you; support from parents for parents.
+    </p>
+    <p>We ask that you have at least two years experience as a parent to join Togethernest as a mentor.</p>
+    <p>Continue below to join the mentorship program as a mentor.</p>
     <div class="mentor-info-btn-container">
       <%= button_to "Be a mentor", join_mentorship_path, class: "mentor-info-btn-hp" %>
      </div>

--- a/app/views/mentorships/show.html.erb
+++ b/app/views/mentorships/show.html.erb
@@ -25,9 +25,9 @@
       <%= link_to "Find a mentor", find_mentorship_path, class: "mentor-info-btn-hp"%>
     </div>
     <p>Are you interested in becoming a Mentor yourself?</p>
-    <p>Being a mentor and guiding a new parent to become more confident in their parenting skills can be greatly rewarding.</p>
+    <p>Guiding a new parent to become more confident in their parenting skills can be greatly rewarding.</p>
     <p>
-      After having benefited from community and parenting support at Togethernest yourself, why not give back to the community and help someone else navigate the challenges of parenthood? You'll help us offer accessible support to parents in similar circumstance as you; support from parents for parents.
+      After having benefited from community and parenting support at Togethernest yourself, why not give back to the community and help someone else navigate the challenges of parenthood? You'll help us offer accessible support to parents in similar circumstances as you; support from parents for parents.
     </p>
     <p>We ask that you have at least two years experience as a parent to join Togethernest as a mentor.</p>
     <p>Continue below to join the mentorship program as a mentor.</p>

--- a/app/views/mentorships/show.html.erb
+++ b/app/views/mentorships/show.html.erb
@@ -24,7 +24,7 @@
     <div class="mentor-info-btn-container">
       <%= link_to "Find a mentor", find_mentorship_path, class: "mentor-info-btn-hp"%>
     </div>
-    <p>Are you interested in becoming a Mentor yourself?</p>
+    <p>Are you interested in becoming a Mentor?</p>
     <p>Guiding a new parent to become more confident in their parenting skills can be greatly rewarding.</p>
     <p>
       After having benefited from community and parenting support at Togethernest yourself, why not give back to the community and help someone else navigate the challenges of parenthood? You'll help us offer accessible support to parents in similar circumstances as you; support from parents for parents.


### PR DESCRIPTION
- First version of the mentor info page with all info present. This will need some editing. Ideally I'd like to create two columns. Could use Matt's advice :)
<img width="570" alt="Screenshot 2024-05-10 at 10 30 42 pm" src="https://github.com/tarakoomen/TogetherNest-/assets/152606014/e6fae912-7e83-432c-86a2-19cf15a04705">

- Wrote the first version of code that only allows users with a minimum of 2 years parenting experience to become mentors. Code is not in the right place yet but it's almost there, will ask advice from teachers. 

- Slightly updated the 'become a mentor' form where we capture the mentor's information (postcode, parenting experience and bio)
<img width="743" alt="Screenshot 2024-05-10 at 10 34 03 pm" src="https://github.com/tarakoomen/TogetherNest-/assets/152606014/727e1d9a-1d99-44fa-91a4-32045d032632">
